### PR TITLE
Fix unit conversion for A1C estimation

### DIFF
--- a/src/conversions.ts
+++ b/src/conversions.ts
@@ -58,7 +58,8 @@ export function estimateA1CFromAverage(
   avgGlucose: number,
   unit: GlucoseUnit = MG_DL
 ): number {
-  const glucoseMgdl = unit === MMOL_L ? avgGlucose * 18 : avgGlucose
+  const glucoseMgdl =
+    unit === MMOL_L ? avgGlucose * MGDL_MMOLL_CONVERSION : avgGlucose
   return +((glucoseMgdl + 46.7) / 28.7).toFixed(2)
 }
 


### PR DESCRIPTION
## Summary
- use the shared MGDL_MMOLL_CONVERSION factor when estimating A1C from average glucose

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543ca4e47c8323aabf5fa7aaccf52d