### PR TITLE
Add date validation

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -42,6 +42,9 @@ export function formatPercentage(val: number, digits = 1): string {
  * @see https://en.wikipedia.org/wiki/ISO_8601
  */
 export function formatDate(iso: string, timeZone?: string): string {
+  if (isNaN(Date.parse(iso))) {
+    throw new RangeError('Invalid ISO timestamp')
+  }
   return new Date(iso).toLocaleString('en-US', {
     timeZone,
     year: 'numeric',

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -29,4 +29,9 @@ describe('Formatters', () => {
     const tzFormatted = formatDate(iso, 'America/New_York')
     expect(tzFormatted).toMatch(/Mar 15, 2024/)
   })
+
+  it('throws on invalid ISO timestamps', () => {
+    expect(() => formatDate('not-a-date')).toThrow(RangeError)
+    expect(() => formatDate('')).toThrow('Invalid ISO timestamp')
+  })
 })


### PR DESCRIPTION
## Summary
- validate ISO timestamps in `formatDate`
- test RangeError case in formatter tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685441db45fc832389733080cf8e37e2