### PR TITLE
Handle invalid formatDate input

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -42,7 +42,11 @@ export function formatPercentage(val: number, digits = 1): string {
  * @see https://en.wikipedia.org/wiki/ISO_8601
  */
 export function formatDate(iso: string, timeZone?: string): string {
-  return new Date(iso).toLocaleString('en-US', {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) {
+    throw new RangeError('Invalid ISO date string')
+  }
+  return date.toLocaleString('en-US', {
     timeZone,
     year: 'numeric',
     month: 'short',

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -29,4 +29,8 @@ describe('Formatters', () => {
     const tzFormatted = formatDate(iso, 'America/New_York')
     expect(tzFormatted).toMatch(/Mar 15, 2024/)
   })
+
+  it('throws RangeError for invalid dates', () => {
+    expect(() => formatDate('invalid')).toThrow(RangeError)
+  })
 })


### PR DESCRIPTION
## Summary
- add invalid date test case
- ensure `formatDate` throws `RangeError` on bad input

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685441f025bc8323be1f3f14f23338db