### PR TITLE
Fix TIR function docs

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -28,8 +28,8 @@ Welcome to the **diabetic-utils** API Reference. All functions are fully type-sa
 
 | Function               | Signature                                                          | Description                           |
 | ---------------------- | ------------------------------------------------------------------ | ------------------------------------- |
-| `calculateTimeInRange` | `({ readings, unit, range }: TIROptions) => TIRResult`             | Calculate time in range, below, above |
-| `getTIRSummary`        | `(results: TIRResult[]) => TIRResult`                              | Summarize multiple TIR results        |
+| `calculateTimeInRange` | `(readings: number[], lower: number, upper: number) => number` | Percentage of readings within range  |
+| `getTIRSummary`        | `(result: TIRResult) => string` | Summarize a TIR result as a string |
 | `groupByDay`           | `(readings: GlucoseReading[]) => Record<string, GlucoseReading[]>` | Group readings by day                 |
 
 ---

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -34,7 +34,7 @@ const a1c = estimateA1CFromAverage(avgGlucose, 'mg/dL') // 5.9
 ## Calculate Time-in-Range (TIR)
 
 ```ts
-import { calculateTimeInRange } from 'diabetic-utils'
+import { calculateTIR } from 'diabetic-utils'
 
 const readings = [
   { value: 90, unit: 'mg/dL', timestamp: '2024-03-20T10:00:00Z' },
@@ -43,7 +43,7 @@ const readings = [
   { value: 200, unit: 'mg/dL', timestamp: '2024-03-20T13:00:00Z' },
   { value: 80, unit: 'mg/dL', timestamp: '2024-03-20T14:00:00Z' },
 ]
-const tir = calculateTimeInRange({ readings, unit: 'mg/dL', range: [70, 180] })
+const tir = calculateTIR(readings, { min: 70, max: 180 })
 // tir = { inRange: 3, belowRange: 1, aboveRange: 1 }
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ import {
   mgDlToMmolL,
   mmolLToMgDl,
   estimateA1CFromAverage,
-  calculateTimeInRange,
+  calculateTIR,
   formatGlucose,
   parseGlucoseString,
   isValidGlucoseValue,
@@ -49,8 +49,7 @@ const readings = [
   { value: 200, unit: 'mg/dL', timestamp: '2024-03-20T13:00:00Z' },
   { value: 80, unit: 'mg/dL', timestamp: '2024-03-20T14:00:00Z' },
 ]
-const tir = calculateTimeInRange({ readings, unit: 'mg/dL', range: [70, 180] }) // { inRange: 3, belowRange: 1, aboveRange: 1 }
-
+const tir = calculateTIR(readings, { min: 70, max: 180 }) // { inRange: 3, belowRange: 1, aboveRange: 1 }
 // Format glucose value
 const formatted = formatGlucose(5.5, 'mmol/L') // '5.5 mmol/L'
 


### PR DESCRIPTION
## Summary
- update `calculateTimeInRange` and `getTIRSummary` signatures
- fix getting started example to use `calculateTIR`
- adjust examples to show the correct TIR usage

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685441f1765883239a92a03c4807ca37