### PR TITLE
Add advanced type 2 TIR breakdown utilities

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,20 @@ export interface TIRResult {
 }
 
 /**
+ * Advanced Time-in-Range (TIR) result with clinical level 1/2 breakdowns.
+ * Provides the percentage of readings falling into each ADA-recommended
+ * glucose band for nonpregnant adults with type 1 or type 2 diabetes.
+ * @see https://care.diabetesjournals.org/content/44/1/17
+ */
+export interface AdvancedTIRResult {
+  veryLow: number
+  low: number
+  inRange: number
+  high: number
+  veryHigh: number
+}
+
+/**
  * Options for clinical GMI (Glucose Management Indicator) estimation.
  * Used to standardize GMI calculation input.
  * @see https://diatribe.org/glucose-management-indicator-gmi


### PR DESCRIPTION
## Summary
- add an AdvancedTIRResult type to expose level 1 and level 2 glucose bands
- implement calculateType2AdvancedTIR with configurable ADA-aligned thresholds and precision
- cover the new functionality with Vitest suites including unit conversions and validation

## Testing
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68ea0487328c832393cbca1828fcfbe5