### PR TITLE
refactor: modernize type guards and eliminate 'any' types

### DIFF
--- a/src/guards.ts
+++ b/src/guards.ts
@@ -10,13 +10,11 @@ import type { EstimateGMIOptions } from './types'
 export function isEstimateGMIOptions(
   input: unknown
 ): input is EstimateGMIOptions {
+  if (typeof input !== 'object' || input === null) return false
+
+  const candidate = input as Record<string, unknown>
   return (
-    typeof input === 'object' &&
-    input !== null &&
-    'value' in input &&
-    'unit' in input &&
-    typeof (input as any).value === 'number' &&
-    typeof (input as any).unit === 'string'
+    typeof candidate.value === 'number' && typeof candidate.unit === 'string'
   )
 }
 

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -7,7 +7,7 @@
  * @returns True if value is a valid fasting insulin (µIU/mL)
  * @see https://www.ncbi.nlm.nih.gov/books/NBK279396/ (normal fasting insulin: ~2-25 µIU/mL, but allow wider plausible range for outliers)
  */
-export function isValidInsulin(value: unknown): boolean {
+export function isValidInsulin(value: unknown): value is number {
   return (
     typeof value === 'number' &&
     Number.isFinite(value) &&


### PR DESCRIPTION
## 🛡️ Modernize Type Guards

### Problem
Type guards used `any` type, which bypasses TypeScript's type checking.

### Solution
- Replaced `(input as any)` with `Record<string, unknown>` pattern
- Added type predicate `value is number` to validators
- Modern TypeScript best practices

### Benefits
- ✅ Better type safety
- ✅ No `any` types in codebase
- ✅ TypeScript narrows types after validation
- ✅ Follows 2024 TS best practices

### Before/After
```typescript
// Before
typeof (input as any).value === 'number'

// After
const candidate = input as Record<string, unknown>
typeof candidate.value === 'number'