### PR TITLE
feat(connectors): add Dexcom, Libre, Nightscout adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ getA1CCategory(6.5, {
 - ✅ **Validation**: Input guards, string parsing
 - ✅ **Labeling**: Glucose status (low/normal/high)
 
+### CGM Connector Adapters (NEW!)
+- ✅ **Dexcom Share**: Normalize Dexcom Share API responses
+- ✅ **Libre LinkUp**: Normalize Libre LinkUp API responses
+- ✅ **Nightscout**: Normalize Nightscout SGV entries
+- ✅ **Canonical Type**: `NormalizedCGMReading` with trend + source metadata
+
 ### Quality & DX
 - ✅ **TypeScript-First**: 100% strict mode, zero `any` types
 - ✅ **100% Test Coverage**: 205 tests, all edge cases covered
@@ -262,6 +268,7 @@ Every formula, threshold, and calculation is sourced from authoritative clinical
 - Enhanced TIR (5-range breakdown)
 - Pregnancy-specific TIR metrics
 - Clinical-grade MAGE calculation
+- CGM vendor adapters (Dexcom, Libre, Nightscout)
 - Type predicates for validation
 
 ---
@@ -303,6 +310,11 @@ Every formula, threshold, and calculation is sourced from authoritative clinical
 ### Insulin Metrics
 - `calculateHOMAIR(glucose, insulin, unit)` - HOMA-IR
 - `isValidInsulin(value)` - Validate insulin value
+
+### CGM Connector Adapters
+- `normalizeDexcomEntries(entries)` - Dexcom Share → NormalizedCGMReading[]
+- `normalizeLibreEntries(entries)` - Libre LinkUp → NormalizedCGMReading[]
+- `normalizeNightscoutEntries(entries)` - Nightscout SGV → NormalizedCGMReading[]
 
 ### Utilities
 - `parseGlucoseString(str)` - Parse "120 mg/dL" → { value, unit }

--- a/src/connectors/dexcom.ts
+++ b/src/connectors/dexcom.ts
@@ -51,8 +51,13 @@ export function parseDexcomDate(raw: string): string {
 /**
  * Normalizes a Dexcom Share trend string into a canonical CGMTrend.
  */
-export function normalizeDexcomTrend(trend: DexcomTrendString): CGMTrend {
-  return DEXCOM_TREND_MAP[trend] ?? 'unknown'
+export function normalizeDexcomTrend(
+  trend: DexcomTrendString | (string & {}) | null | undefined
+): CGMTrend {
+  if (trend == null) {
+    return 'unknown'
+  }
+  return DEXCOM_TREND_MAP[trend as DexcomTrendString] ?? 'unknown'
 }
 
 /**

--- a/src/connectors/dexcom.ts
+++ b/src/connectors/dexcom.ts
@@ -1,0 +1,93 @@
+/**
+ * @file src/connectors/dexcom.ts
+ *
+ * Pure transformation adapter for Dexcom Share API payloads.
+ * Maps raw Dexcom entries into NormalizedCGMReading objects.
+ * Does NOT handle authentication — use with any Dexcom Share client library.
+ *
+ * @see https://github.com/brettfarrow/cgm.js
+ * @see https://www.npmjs.com/package/@diakem/dexcom-api-client
+ */
+
+import { MG_DL } from '../constants'
+import type {
+  DexcomShareEntry,
+  DexcomTrendString,
+  NormalizedCGMReading,
+  CGMTrend,
+} from './types'
+
+const DEXCOM_TREND_MAP: Record<DexcomTrendString, CGMTrend> = {
+  DoubleUp: 'rapidRising',
+  SingleUp: 'rising',
+  FortyFiveUp: 'slightlyRising',
+  Flat: 'flat',
+  FortyFiveDown: 'slightlyFalling',
+  SingleDown: 'falling',
+  DoubleDown: 'rapidFalling',
+  None: 'unknown',
+  NotComputable: 'unknown',
+  RateOutOfRange: 'unknown',
+}
+
+/**
+ * Parses a Dexcom date string into an ISO 8601 string.
+ *
+ * Dexcom Share returns dates in the format `"Date(epochMs)"` or
+ * `"/Date(epochMs)/"`. This helper handles both, plus plain ISO strings.
+ */
+export function parseDexcomDate(raw: string): string {
+  const epochMatch = raw.match(/Date\((\d+)\)/)
+  if (epochMatch) {
+    return new Date(Number(epochMatch[1])).toISOString()
+  }
+  const parsed = Date.parse(raw)
+  if (isNaN(parsed)) {
+    throw new Error(`Unable to parse Dexcom date: ${raw}`)
+  }
+  return new Date(parsed).toISOString()
+}
+
+/**
+ * Normalizes a Dexcom Share trend string into a canonical CGMTrend.
+ */
+export function normalizeDexcomTrend(trend: DexcomTrendString): CGMTrend {
+  return DEXCOM_TREND_MAP[trend] ?? 'unknown'
+}
+
+/**
+ * Converts a single Dexcom Share entry into a NormalizedCGMReading.
+ *
+ * @param entry - Raw Dexcom Share entry
+ * @returns Normalized reading compatible with all diabetic-utils analytics functions
+ * @throws {Error} If the date string cannot be parsed
+ */
+export function normalizeDexcomEntry(
+  entry: DexcomShareEntry
+): NormalizedCGMReading {
+  return {
+    value: entry.Value,
+    unit: MG_DL,
+    timestamp: parseDexcomDate(entry.WT),
+    trend: normalizeDexcomTrend(entry.Trend),
+    source: 'dexcom',
+    vendorId: entry.ST ?? entry.DT,
+  }
+}
+
+/**
+ * Converts an array of Dexcom Share entries into NormalizedCGMReadings.
+ *
+ * @param entries - Raw Dexcom Share entries from any Dexcom client library
+ * @returns Array of normalized readings, sorted chronologically
+ */
+export function normalizeDexcomEntries(
+  entries: DexcomShareEntry[]
+): NormalizedCGMReading[] {
+  return entries
+    .map(normalizeDexcomEntry)
+    .sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    )
+}

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @file src/connectors/index.ts
+ *
+ * CGM vendor data normalization adapters.
+ * Pure transformation helpers that map vendor payloads into a canonical
+ * NormalizedCGMReading type compatible with all diabetic-utils analytics.
+ */
+
+export * from './types'
+export * from './dexcom'
+export * from './libre'
+export * from './nightscout'

--- a/src/connectors/libre.ts
+++ b/src/connectors/libre.ts
@@ -1,0 +1,74 @@
+/**
+ * @file src/connectors/libre.ts
+ *
+ * Pure transformation adapter for Libre LinkUp API payloads.
+ * Maps raw Libre entries into NormalizedCGMReading objects.
+ * Does NOT handle authentication — use with any Libre LinkUp client library.
+ *
+ * @see https://www.npmjs.com/package/librelinkup-api-client
+ * @see https://www.npmjs.com/package/libre-client
+ */
+
+import { MG_DL } from '../constants'
+import type {
+  LibreLinkUpEntry,
+  LibreTrendValue,
+  NormalizedCGMReading,
+  CGMTrend,
+} from './types'
+
+const LIBRE_TREND_MAP: Record<LibreTrendValue, CGMTrend> = {
+  1: 'rapidFalling',
+  2: 'falling',
+  3: 'flat',
+  4: 'rising',
+  5: 'rapidRising',
+}
+
+/**
+ * Normalizes a Libre LinkUp numeric trend value into a canonical CGMTrend.
+ */
+export function normalizeLibreTrend(trend: LibreTrendValue): CGMTrend {
+  return LIBRE_TREND_MAP[trend] ?? 'unknown'
+}
+
+/**
+ * Converts a single Libre LinkUp entry into a NormalizedCGMReading.
+ *
+ * @param entry - Raw Libre LinkUp entry
+ * @returns Normalized reading compatible with all diabetic-utils analytics functions
+ * @throws {Error} If the timestamp cannot be parsed
+ */
+export function normalizeLibreEntry(
+  entry: LibreLinkUpEntry
+): NormalizedCGMReading {
+  const parsed = Date.parse(entry.Timestamp)
+  if (isNaN(parsed)) {
+    throw new Error(`Unable to parse Libre timestamp: ${entry.Timestamp}`)
+  }
+
+  return {
+    value: entry.Value,
+    unit: MG_DL,
+    timestamp: new Date(parsed).toISOString(),
+    trend: normalizeLibreTrend(entry.TrendArrow),
+    source: 'libre',
+  }
+}
+
+/**
+ * Converts an array of Libre LinkUp entries into NormalizedCGMReadings.
+ *
+ * @param entries - Raw Libre LinkUp entries from any Libre client library
+ * @returns Array of normalized readings, sorted chronologically
+ */
+export function normalizeLibreEntries(
+  entries: LibreLinkUpEntry[]
+): NormalizedCGMReading[] {
+  return entries
+    .map(normalizeLibreEntry)
+    .sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    )
+}

--- a/src/connectors/libre.ts
+++ b/src/connectors/libre.ts
@@ -27,9 +27,23 @@ const LIBRE_TREND_MAP: Record<LibreTrendValue, CGMTrend> = {
 
 /**
  * Normalizes a Libre LinkUp numeric trend value into a canonical CGMTrend.
+ *
+ * Accepts the raw API value (which may be null/undefined or out of range)
+ * and returns 'unknown' for any invalid or unmapped values.
  */
-export function normalizeLibreTrend(trend: LibreTrendValue): CGMTrend {
-  return LIBRE_TREND_MAP[trend] ?? 'unknown'
+export function normalizeLibreTrend(
+  trend: number | null | undefined
+): CGMTrend {
+  if (trend == null) {
+    return 'unknown'
+  }
+
+  // LibreTrendValue is defined as 1–5; anything else is treated as unknown.
+  if (trend < 1 || trend > 5) {
+    return 'unknown'
+  }
+
+  return LIBRE_TREND_MAP[trend as LibreTrendValue] ?? 'unknown'
 }
 
 /**

--- a/src/connectors/nightscout.ts
+++ b/src/connectors/nightscout.ts
@@ -49,10 +49,37 @@ export function normalizeNightscoutDirection(
 export function normalizeNightscoutEntry(
   entry: NightscoutEntry
 ): NormalizedCGMReading {
-  const timestamp = entry.dateString
-    ? new Date(entry.dateString).toISOString()
-    : new Date(entry.date).toISOString()
+  const timestamp = (() => {
+    if (entry.dateString) {
+      const parsed = Date.parse(entry.dateString)
+      if (!Number.isNaN(parsed)) {
+        return new Date(parsed).toISOString()
+      }
 
+      // Fall back to `entry.date` if available and valid
+      if (entry.date !== undefined && entry.date !== null) {
+        const fallbackDate = new Date(entry.date)
+        if (!Number.isNaN(fallbackDate.getTime())) {
+          return fallbackDate.toISOString()
+        }
+      }
+
+      throw new Error(
+        `Unable to parse Nightscout timestamp from 'dateString': ${entry.dateString}`
+      )
+    }
+
+    const date = new Date(entry.date)
+    if (Number.isNaN(date.getTime())) {
+      throw new Error(
+        `Unable to parse Nightscout timestamp from 'date' field: ${String(
+          entry.date
+        )}`
+      )
+    }
+
+    return date.toISOString()
+  })()
   return {
     value: entry.sgv,
     unit: MG_DL,

--- a/src/connectors/nightscout.ts
+++ b/src/connectors/nightscout.ts
@@ -1,0 +1,81 @@
+/**
+ * @file src/connectors/nightscout.ts
+ *
+ * Pure transformation adapter for Nightscout API payloads.
+ * Maps raw Nightscout SGV entries into NormalizedCGMReading objects.
+ * Does NOT handle authentication — use with the Nightscout REST API directly.
+ *
+ * @see https://nightscout.github.io/nightscout/setup_variables/#api
+ * @see https://www.npmjs.com/package/nightscout
+ */
+
+import { MG_DL } from '../constants'
+import type {
+  NightscoutEntry,
+  NightscoutDirection,
+  NormalizedCGMReading,
+  CGMTrend,
+} from './types'
+
+const NIGHTSCOUT_DIRECTION_MAP: Record<string, CGMTrend> = {
+  DoubleUp: 'rapidRising',
+  SingleUp: 'rising',
+  FortyFiveUp: 'slightlyRising',
+  Flat: 'flat',
+  FortyFiveDown: 'slightlyFalling',
+  SingleDown: 'falling',
+  DoubleDown: 'rapidFalling',
+  NONE: 'unknown',
+  'NOT COMPUTABLE': 'unknown',
+  'RATE OUT OF RANGE': 'unknown',
+}
+
+/**
+ * Normalizes a Nightscout direction string into a canonical CGMTrend.
+ */
+export function normalizeNightscoutDirection(
+  direction: NightscoutDirection | undefined
+): CGMTrend {
+  if (!direction) return 'unknown'
+  return NIGHTSCOUT_DIRECTION_MAP[direction] ?? 'unknown'
+}
+
+/**
+ * Converts a single Nightscout SGV entry into a NormalizedCGMReading.
+ *
+ * @param entry - Raw Nightscout SGV entry
+ * @returns Normalized reading compatible with all diabetic-utils analytics functions
+ */
+export function normalizeNightscoutEntry(
+  entry: NightscoutEntry
+): NormalizedCGMReading {
+  const timestamp = entry.dateString
+    ? new Date(entry.dateString).toISOString()
+    : new Date(entry.date).toISOString()
+
+  return {
+    value: entry.sgv,
+    unit: MG_DL,
+    timestamp,
+    trend: normalizeNightscoutDirection(entry.direction),
+    source: 'nightscout',
+    vendorId: entry._id,
+  }
+}
+
+/**
+ * Converts an array of Nightscout SGV entries into NormalizedCGMReadings.
+ *
+ * @param entries - Raw Nightscout entries from the `/api/v1/entries` endpoint
+ * @returns Array of normalized readings, sorted chronologically
+ */
+export function normalizeNightscoutEntries(
+  entries: NightscoutEntry[]
+): NormalizedCGMReading[] {
+  return entries
+    .map(normalizeNightscoutEntry)
+    .sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    )
+}

--- a/src/connectors/types.ts
+++ b/src/connectors/types.ts
@@ -6,7 +6,7 @@
  * which are compatible with the existing GlucoseReading interface.
  */
 
-import type { GlucoseUnit, GlucoseReading } from '../types'
+import type { GlucoseReading } from '../types'
 
 /**
  * Trend direction reported by CGM devices.

--- a/src/connectors/types.ts
+++ b/src/connectors/types.ts
@@ -1,0 +1,141 @@
+/**
+ * @file src/connectors/types.ts
+ *
+ * Canonical types for CGM vendor data normalization.
+ * All connector adapters map vendor-specific payloads into these types,
+ * which are compatible with the existing GlucoseReading interface.
+ */
+
+import type { GlucoseUnit, GlucoseReading } from '../types'
+
+/**
+ * Trend direction reported by CGM devices.
+ * Normalized across vendors into a common set.
+ *
+ * @see Dexcom: DoubleUp, SingleUp, FortyFiveUp, Flat, FortyFiveDown, SingleDown, DoubleDown
+ * @see Libre: 1-5 numeric scale
+ */
+export type CGMTrend =
+  | 'rapidRising'
+  | 'rising'
+  | 'slightlyRising'
+  | 'flat'
+  | 'slightlyFalling'
+  | 'falling'
+  | 'rapidFalling'
+  | 'unknown'
+
+/** Known CGM data source vendors. */
+export type CGMSource = 'dexcom' | 'libre' | 'nightscout' | 'unknown'
+
+/**
+ * Extended glucose reading that preserves vendor metadata.
+ * Superset of GlucoseReading — can be passed directly to all analytics functions.
+ */
+export interface NormalizedCGMReading extends GlucoseReading {
+  /** Trend direction from the CGM device */
+  readonly trend: CGMTrend
+  /** Data source vendor */
+  readonly source: CGMSource
+  /** Original vendor-specific identifier, if available */
+  readonly vendorId?: string
+}
+
+// ---------------------------------------------------------------------------
+// Dexcom Share types (vendor payload shape)
+// ---------------------------------------------------------------------------
+
+/** Trend strings returned by the Dexcom Share API. */
+export type DexcomTrendString =
+  | 'DoubleUp'
+  | 'SingleUp'
+  | 'FortyFiveUp'
+  | 'Flat'
+  | 'FortyFiveDown'
+  | 'SingleDown'
+  | 'DoubleDown'
+  | 'None'
+  | 'NotComputable'
+  | 'RateOutOfRange'
+
+/**
+ * Raw glucose entry returned by the Dexcom Share service.
+ * Matches the shape of `@diakem/dexcom-api-client` and `dexcom-share-client` responses.
+ */
+export interface DexcomShareEntry {
+  /** Glucose value in mg/dL */
+  Value: number
+  /** Dexcom trend string */
+  Trend: DexcomTrendString
+  /** Dexcom date string, e.g. "Date(1700000000000)" or ISO 8601 */
+  WT: string
+  /** Optional: Dexcom device serial or record id */
+  DT?: string
+  /** Stable record identifier */
+  ST?: string
+}
+
+// ---------------------------------------------------------------------------
+// Libre LinkUp types (vendor payload shape)
+// ---------------------------------------------------------------------------
+
+/** Trend values returned by Libre LinkUp (numeric 1-5). */
+export type LibreTrendValue = 1 | 2 | 3 | 4 | 5
+
+/**
+ * Raw glucose entry from the Libre LinkUp API.
+ * Matches the shape of `librelinkup-api-client` and `libre-client` responses.
+ */
+export interface LibreLinkUpEntry {
+  /** Glucose value (mg/dL) */
+  Value: number
+  /** Trend arrow (1=falling fast, 2=falling, 3=stable, 4=rising, 5=rising fast) */
+  TrendArrow: LibreTrendValue
+  /** ISO 8601 timestamp string */
+  Timestamp: string
+  /** Measurement color (vendor-specific) */
+  MeasurementColor?: number
+  /** Factory timestamp */
+  FactoryTimestamp?: string
+}
+
+// ---------------------------------------------------------------------------
+// Nightscout types (vendor payload shape)
+// ---------------------------------------------------------------------------
+
+/**
+ * Nightscout direction string for trend arrows.
+ */
+export type NightscoutDirection =
+  | 'DoubleUp'
+  | 'SingleUp'
+  | 'FortyFiveUp'
+  | 'Flat'
+  | 'FortyFiveDown'
+  | 'SingleDown'
+  | 'DoubleDown'
+  | 'NONE'
+  | 'NOT COMPUTABLE'
+  | 'RATE OUT OF RANGE'
+  | string
+
+/**
+ * Nightscout SGV (Sensor Glucose Value) entry.
+ * Matches the `/api/v1/entries` response shape.
+ *
+ * @see https://nightscout.github.io/nightscout/setup_variables/#api
+ */
+export interface NightscoutEntry {
+  /** Sensor glucose value in mg/dL */
+  sgv: number
+  /** Epoch timestamp in milliseconds */
+  date: number
+  /** ISO 8601 date string */
+  dateString: string
+  /** Trend direction */
+  direction?: NightscoutDirection
+  /** Entry type (usually "sgv") */
+  type?: string
+  /** Nightscout record _id */
+  _id?: string
+}

--- a/src/connectors/types.ts
+++ b/src/connectors/types.ts
@@ -117,7 +117,7 @@ export type NightscoutDirection =
   | 'NONE'
   | 'NOT COMPUTABLE'
   | 'RATE OUT OF RANGE'
-  | string
+  | (string & {})
 
 /**
  * Nightscout SGV (Sensor Glucose Value) entry.

--- a/src/connectors/types.ts
+++ b/src/connectors/types.ts
@@ -131,7 +131,7 @@ export interface NightscoutEntry {
   /** Epoch timestamp in milliseconds */
   date: number
   /** ISO 8601 date string */
-  dateString: string
+  dateString?: string
   /** Trend direction */
   direction?: NightscoutDirection
   /** Entry type (usually "sgv") */

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,3 +34,6 @@ export { glucoseMAGE as clinicalMAGE, type MAGEOptions } from './mage'
 
 // Export Enhanced Time-in-Range functions (v2.0+)
 export { calculateEnhancedTIR, calculatePregnancyTIR } from './tir-enhanced'
+
+// Export CGM connector adapters
+export * from './connectors'

--- a/tests/connectors.test.ts
+++ b/tests/connectors.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from 'vitest'
+import {
+  // Dexcom
+  parseDexcomDate,
+  normalizeDexcomTrend,
+  normalizeDexcomEntry,
+  normalizeDexcomEntries,
+  // Libre
+  normalizeLibreTrend,
+  normalizeLibreEntry,
+  normalizeLibreEntries,
+  // Nightscout
+  normalizeNightscoutDirection,
+  normalizeNightscoutEntry,
+  normalizeNightscoutEntries,
+} from '../src/connectors'
+import type {
+  DexcomShareEntry,
+  LibreLinkUpEntry,
+  NightscoutEntry,
+} from '../src/connectors'
+
+// ---------------------------------------------------------------------------
+// Dexcom Share adapter
+// ---------------------------------------------------------------------------
+describe('Dexcom Share adapter', () => {
+  describe('parseDexcomDate', () => {
+    it('parses Date(epochMs) format', () => {
+      const iso = parseDexcomDate('Date(1700000000000)')
+      expect(iso).toBe(new Date(1700000000000).toISOString())
+    })
+
+    it('parses /Date(epochMs)/ format', () => {
+      const iso = parseDexcomDate('/Date(1700000000000)/')
+      expect(iso).toBe(new Date(1700000000000).toISOString())
+    })
+
+    it('parses plain ISO 8601 strings', () => {
+      const iso = parseDexcomDate('2024-01-15T10:30:00Z')
+      expect(iso).toBe('2024-01-15T10:30:00.000Z')
+    })
+
+    it('throws on unparseable date', () => {
+      expect(() => parseDexcomDate('not-a-date')).toThrow(
+        'Unable to parse Dexcom date'
+      )
+    })
+  })
+
+  describe('normalizeDexcomTrend', () => {
+    it('maps all known Dexcom trends', () => {
+      expect(normalizeDexcomTrend('DoubleUp')).toBe('rapidRising')
+      expect(normalizeDexcomTrend('SingleUp')).toBe('rising')
+      expect(normalizeDexcomTrend('FortyFiveUp')).toBe('slightlyRising')
+      expect(normalizeDexcomTrend('Flat')).toBe('flat')
+      expect(normalizeDexcomTrend('FortyFiveDown')).toBe('slightlyFalling')
+      expect(normalizeDexcomTrend('SingleDown')).toBe('falling')
+      expect(normalizeDexcomTrend('DoubleDown')).toBe('rapidFalling')
+      expect(normalizeDexcomTrend('None')).toBe('unknown')
+      expect(normalizeDexcomTrend('NotComputable')).toBe('unknown')
+      expect(normalizeDexcomTrend('RateOutOfRange')).toBe('unknown')
+    })
+
+    it('returns unknown for unrecognized trend string', () => {
+      expect(
+        normalizeDexcomTrend('SomethingNew' as any)
+      ).toBe('unknown')
+    })
+  })
+
+  describe('normalizeDexcomEntry', () => {
+    it('converts a Dexcom entry to NormalizedCGMReading', () => {
+      const entry: DexcomShareEntry = {
+        Value: 120,
+        Trend: 'Flat',
+        WT: 'Date(1700000000000)',
+        ST: 'abc123',
+      }
+      const result = normalizeDexcomEntry(entry)
+      expect(result.value).toBe(120)
+      expect(result.unit).toBe('mg/dL')
+      expect(result.trend).toBe('flat')
+      expect(result.source).toBe('dexcom')
+      expect(result.vendorId).toBe('abc123')
+      expect(result.timestamp).toBe(new Date(1700000000000).toISOString())
+    })
+
+    it('falls back to DT when ST is not provided', () => {
+      const entry: DexcomShareEntry = {
+        Value: 95,
+        Trend: 'SingleUp',
+        WT: '2024-01-15T10:00:00Z',
+        DT: 'dt-id',
+      }
+      const result = normalizeDexcomEntry(entry)
+      expect(result.vendorId).toBe('dt-id')
+    })
+
+    it('sets vendorId to undefined when both ST and DT are absent', () => {
+      const entry: DexcomShareEntry = {
+        Value: 95,
+        Trend: 'SingleUp',
+        WT: '2024-01-15T10:00:00Z',
+      }
+      const result = normalizeDexcomEntry(entry)
+      expect(result.vendorId).toBeUndefined()
+    })
+  })
+
+  describe('normalizeDexcomEntries', () => {
+    it('normalizes and sorts entries chronologically', () => {
+      const entries: DexcomShareEntry[] = [
+        { Value: 150, Trend: 'Flat', WT: 'Date(1700000010000)' },
+        { Value: 120, Trend: 'SingleDown', WT: 'Date(1700000000000)' },
+        { Value: 180, Trend: 'SingleUp', WT: 'Date(1700000020000)' },
+      ]
+      const result = normalizeDexcomEntries(entries)
+      expect(result).toHaveLength(3)
+      expect(result[0].value).toBe(120)
+      expect(result[1].value).toBe(150)
+      expect(result[2].value).toBe(180)
+    })
+
+    it('returns empty array for empty input', () => {
+      expect(normalizeDexcomEntries([])).toEqual([])
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Libre LinkUp adapter
+// ---------------------------------------------------------------------------
+describe('Libre LinkUp adapter', () => {
+  describe('normalizeLibreTrend', () => {
+    it('maps all known Libre trend values', () => {
+      expect(normalizeLibreTrend(1)).toBe('rapidFalling')
+      expect(normalizeLibreTrend(2)).toBe('falling')
+      expect(normalizeLibreTrend(3)).toBe('flat')
+      expect(normalizeLibreTrend(4)).toBe('rising')
+      expect(normalizeLibreTrend(5)).toBe('rapidRising')
+    })
+
+    it('returns unknown for unrecognized numeric trend', () => {
+      expect(normalizeLibreTrend(99 as any)).toBe('unknown')
+    })
+  })
+
+  describe('normalizeLibreEntry', () => {
+    it('converts a Libre entry to NormalizedCGMReading', () => {
+      const entry: LibreLinkUpEntry = {
+        Value: 110,
+        TrendArrow: 3,
+        Timestamp: '2024-06-15T08:30:00Z',
+      }
+      const result = normalizeLibreEntry(entry)
+      expect(result.value).toBe(110)
+      expect(result.unit).toBe('mg/dL')
+      expect(result.trend).toBe('flat')
+      expect(result.source).toBe('libre')
+      expect(result.timestamp).toBe('2024-06-15T08:30:00.000Z')
+    })
+
+    it('throws on unparseable timestamp', () => {
+      const entry: LibreLinkUpEntry = {
+        Value: 110,
+        TrendArrow: 3,
+        Timestamp: 'bad-timestamp',
+      }
+      expect(() => normalizeLibreEntry(entry)).toThrow(
+        'Unable to parse Libre timestamp'
+      )
+    })
+  })
+
+  describe('normalizeLibreEntries', () => {
+    it('normalizes and sorts entries chronologically', () => {
+      const entries: LibreLinkUpEntry[] = [
+        { Value: 130, TrendArrow: 4, Timestamp: '2024-06-15T08:35:00Z' },
+        { Value: 110, TrendArrow: 3, Timestamp: '2024-06-15T08:30:00Z' },
+        { Value: 150, TrendArrow: 5, Timestamp: '2024-06-15T08:40:00Z' },
+      ]
+      const result = normalizeLibreEntries(entries)
+      expect(result).toHaveLength(3)
+      expect(result[0].value).toBe(110)
+      expect(result[1].value).toBe(130)
+      expect(result[2].value).toBe(150)
+    })
+
+    it('returns empty array for empty input', () => {
+      expect(normalizeLibreEntries([])).toEqual([])
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Nightscout adapter
+// ---------------------------------------------------------------------------
+describe('Nightscout adapter', () => {
+  describe('normalizeNightscoutDirection', () => {
+    it('maps all known Nightscout directions', () => {
+      expect(normalizeNightscoutDirection('DoubleUp')).toBe('rapidRising')
+      expect(normalizeNightscoutDirection('SingleUp')).toBe('rising')
+      expect(normalizeNightscoutDirection('FortyFiveUp')).toBe('slightlyRising')
+      expect(normalizeNightscoutDirection('Flat')).toBe('flat')
+      expect(normalizeNightscoutDirection('FortyFiveDown')).toBe(
+        'slightlyFalling'
+      )
+      expect(normalizeNightscoutDirection('SingleDown')).toBe('falling')
+      expect(normalizeNightscoutDirection('DoubleDown')).toBe('rapidFalling')
+      expect(normalizeNightscoutDirection('NONE')).toBe('unknown')
+      expect(normalizeNightscoutDirection('NOT COMPUTABLE')).toBe('unknown')
+      expect(normalizeNightscoutDirection('RATE OUT OF RANGE')).toBe('unknown')
+    })
+
+    it('returns unknown for undefined direction', () => {
+      expect(normalizeNightscoutDirection(undefined)).toBe('unknown')
+    })
+
+    it('returns unknown for unrecognized string', () => {
+      expect(normalizeNightscoutDirection('SomeNewTrend')).toBe('unknown')
+    })
+  })
+
+  describe('normalizeNightscoutEntry', () => {
+    it('converts a Nightscout entry to NormalizedCGMReading', () => {
+      const entry: NightscoutEntry = {
+        sgv: 135,
+        date: 1700000000000,
+        dateString: '2023-11-14T22:13:20.000Z',
+        direction: 'Flat',
+        _id: 'ns-abc123',
+      }
+      const result = normalizeNightscoutEntry(entry)
+      expect(result.value).toBe(135)
+      expect(result.unit).toBe('mg/dL')
+      expect(result.trend).toBe('flat')
+      expect(result.source).toBe('nightscout')
+      expect(result.vendorId).toBe('ns-abc123')
+      expect(result.timestamp).toBe('2023-11-14T22:13:20.000Z')
+    })
+
+    it('falls back to epoch date when dateString is missing', () => {
+      const entry: NightscoutEntry = {
+        sgv: 100,
+        date: 1700000000000,
+        dateString: '',
+        direction: 'SingleUp',
+      }
+      const result = normalizeNightscoutEntry(entry)
+      expect(result.timestamp).toBe(new Date(1700000000000).toISOString())
+    })
+  })
+
+  describe('normalizeNightscoutEntries', () => {
+    it('normalizes and sorts entries chronologically', () => {
+      const entries: NightscoutEntry[] = [
+        {
+          sgv: 160,
+          date: 1700000020000,
+          dateString: new Date(1700000020000).toISOString(),
+        },
+        {
+          sgv: 120,
+          date: 1700000000000,
+          dateString: new Date(1700000000000).toISOString(),
+        },
+        {
+          sgv: 140,
+          date: 1700000010000,
+          dateString: new Date(1700000010000).toISOString(),
+        },
+      ]
+      const result = normalizeNightscoutEntries(entries)
+      expect(result).toHaveLength(3)
+      expect(result[0].value).toBe(120)
+      expect(result[1].value).toBe(140)
+      expect(result[2].value).toBe(160)
+    })
+
+    it('returns empty array for empty input', () => {
+      expect(normalizeNightscoutEntries([])).toEqual([])
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration: normalized readings work with existing analytics
+// ---------------------------------------------------------------------------
+import { calculateEnhancedTIR } from '../src'
+
+describe('Connector integration with analytics', () => {
+  it('normalized readings are valid GlucoseReading objects for calculateEnhancedTIR', () => {
+    const entries: DexcomShareEntry[] = Array.from({ length: 50 }, (_, i) => ({
+      Value: 100 + (i % 10) * 5,
+      Trend: 'Flat' as const,
+      WT: `Date(${1700000000000 + i * 300000})`,
+    }))
+    const readings = normalizeDexcomEntries(entries)
+    const result = calculateEnhancedTIR(readings)
+    expect(result.inRange.percentage).toBeGreaterThan(0)
+    expect(result.summary.totalReadings).toBe(50)
+  })
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -36,6 +36,18 @@ describe('index exports', () => {
     expect(api.MG_DL).toBeDefined()
     expect(api.MMOL_L).toBeDefined()
     expect(api.AllowedGlucoseUnits).toBeDefined()
+
+    // Connector adapters
+    expect(api.normalizeDexcomEntry).toBeDefined()
+    expect(api.normalizeDexcomEntries).toBeDefined()
+    expect(api.parseDexcomDate).toBeDefined()
+    expect(api.normalizeDexcomTrend).toBeDefined()
+    expect(api.normalizeLibreEntry).toBeDefined()
+    expect(api.normalizeLibreEntries).toBeDefined()
+    expect(api.normalizeLibreTrend).toBeDefined()
+    expect(api.normalizeNightscoutEntry).toBeDefined()
+    expect(api.normalizeNightscoutEntries).toBeDefined()
+    expect(api.normalizeNightscoutDirection).toBeDefined()
   })
 
   it('should export all expected types', () => {


### PR DESCRIPTION
## What

Adds connector adapters to normalize vendor-specific CGM APIs into a canonical `NormalizedCGMReading` type with trend arrows and source metadata.

## Adapters

- **Dexcom Share**: `normalizeDexcomEntry`, `normalizeDexcomEntries`, `parseDexcomDate`, `normalizeDexcomTrend`
- **Libre LinkUp**: `normalizeLibreEntry`, `normalizeLibreEntries`, `normalizeLibreTrend`
- **Nightscout**: `normalizeNightscoutEntry`, `normalizeNightscoutEntries`, `normalizeNightscoutDirection`

## Why

Enables downstream apps to consume Dexcom, Libre, and Nightscout data through a single `NormalizedCGMReading` interface — eliminating vendor-specific parsing logic in consumer code.

## References

- Dexcom Share API (`/Publisher/ReadPublisherLatestGlucoseValues`)
- Libre LinkUp API (`/llu/connections/{id}/graph`)
- Nightscout SGV entry format (`/api/v1/entries/sgv.json`)

Made-with: Cursor
