### PR TITLE
fix(coverage): restore strict 100% gate with targeted branch tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ TIR calculations per **International Consensus 2019** and **ADA 2024 Guidelines*
 - **Test Helpers**: Reusable test utilities for your own projects
 
 ### ✅ 100% Test Coverage
-- 205 passing tests
+- 295 passing tests
 - Every line, branch, and function covered
 - Defensive code properly documented
 
@@ -244,7 +244,7 @@ getA1CCategory(6.5, {
 
 ### Quality & DX
 - ✅ **TypeScript-First**: 100% strict mode, zero `any` types
-- ✅ **100% Test Coverage**: 283 tests, all edge cases covered
+- ✅ **100% Test Coverage**: 295 tests, all edge cases covered
 - ✅ **Zero Dependencies**: No bloat, tree-shakable
 - ✅ **Published References**: ADA, CDC, ISPAD, PubMed citations
 - ✅ **TSDoc**: Complete API documentation
@@ -426,7 +426,7 @@ diabetic-utils/
 │       └── modd.ts          # Mean of Daily Differences
 ├── tests/
 │   ├── test-helpers.ts      # Shared test utilities
-│   └── *.test.ts            # 100% coverage tests (283 tests)
+│   └── *.test.ts            # 100% coverage tests (295 tests)
 └── dist/                    # Built output (ESM + CJS)
 ```
 

--- a/tests/connectors.test.ts
+++ b/tests/connectors.test.ts
@@ -66,6 +66,11 @@ describe('Dexcom Share adapter', () => {
         normalizeDexcomTrend('SomethingNew' as any)
       ).toBe('unknown')
     })
+
+    it('returns unknown for null or undefined trend', () => {
+      expect(normalizeDexcomTrend(null as any)).toBe('unknown')
+      expect(normalizeDexcomTrend(undefined as any)).toBe('unknown')
+    })
   })
 
   describe('normalizeDexcomEntry', () => {
@@ -142,6 +147,15 @@ describe('Libre LinkUp adapter', () => {
 
     it('returns unknown for unrecognized numeric trend', () => {
       expect(normalizeLibreTrend(99 as any)).toBe('unknown')
+    })
+
+    it('returns unknown for in-range non-integer trend values', () => {
+      expect(normalizeLibreTrend(4.5 as any)).toBe('unknown')
+    })
+
+    it('returns unknown for null or undefined trend', () => {
+      expect(normalizeLibreTrend(null)).toBe('unknown')
+      expect(normalizeLibreTrend(undefined)).toBe('unknown')
     })
   })
 
@@ -248,6 +262,41 @@ describe('Nightscout adapter', () => {
       }
       const result = normalizeNightscoutEntry(entry)
       expect(result.timestamp).toBe(new Date(1700000000000).toISOString())
+    })
+
+    it('falls back to date when dateString is invalid but date is valid', () => {
+      const entry: NightscoutEntry = {
+        sgv: 110,
+        date: 1700000000000,
+        dateString: 'not-a-valid-iso',
+        direction: 'Flat',
+      }
+      const result = normalizeNightscoutEntry(entry)
+      expect(result.timestamp).toBe(new Date(1700000000000).toISOString())
+    })
+
+    it('throws when dateString is invalid and date fallback is invalid', () => {
+      const entry: NightscoutEntry = {
+        sgv: 110,
+        date: 'also-bad' as any,
+        dateString: 'not-a-valid-iso',
+        direction: 'Flat',
+      }
+      expect(() => normalizeNightscoutEntry(entry)).toThrow(
+        "Unable to parse Nightscout timestamp from 'dateString'"
+      )
+    })
+
+    it('throws when dateString is missing and date is invalid', () => {
+      const entry: NightscoutEntry = {
+        sgv: 110,
+        date: 'bad-date' as any,
+        dateString: '',
+        direction: 'Flat',
+      }
+      expect(() => normalizeNightscoutEntry(entry)).toThrow(
+        "Unable to parse Nightscout timestamp from 'date' field"
+      )
     })
   })
 

--- a/tests/tir-enhanced.test.ts
+++ b/tests/tir-enhanced.test.ts
@@ -433,6 +433,26 @@ describe('calculateEnhancedTIR', () => {
       expect(unsortedResult.summary.totalDuration).toBe(sortedResult.summary.totalDuration)
       expect(unsortedResult.summary.totalDuration).toBeGreaterThan(0)
     })
+
+    it('should fall back to default interval when timestamps are invalid', () => {
+      const readings: GlucoseReading[] = [
+        { value: 120, unit: 'mg/dL', timestamp: '' },
+        { value: 130, unit: 'mg/dL', timestamp: 'not-a-date' },
+      ]
+
+      const result = calculateEnhancedTIR(readings)
+      expect(result.summary.totalDuration).toBe(10) // 2 readings * 5 min default
+    })
+
+    it('should fall back to default interval when all timestamp deltas are non-positive', () => {
+      const readings: GlucoseReading[] = [
+        { value: 120, unit: 'mg/dL', timestamp: '2024-01-01T08:00:00Z' },
+        { value: 130, unit: 'mg/dL', timestamp: '2024-01-01T08:00:00Z' },
+      ]
+
+      const result = calculateEnhancedTIR(readings)
+      expect(result.summary.totalDuration).toBe(10) // 2 readings * 5 min default
+    })
   })
 
   describe('Average value calculation', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,11 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      exclude: ['node_modules'],
+      exclude: [
+        'node_modules',
+        'src/connectors/types.ts',
+        'src/interop/types.ts',
+      ],
       all: true,
       include: ['src/**/*.ts'],
       thresholds: {


### PR DESCRIPTION
## Summary
- Restores CI compliance with strict 100% coverage thresholds by adding targeted branch tests for previously uncovered connector and interval-estimation edge paths.
- Excludes type-only files from coverage accounting so coverage thresholds apply to executable runtime code.
- Updates README test-count references to match the current suite size.

## Why
The coverage gate was failing despite broad test health because a few branch paths were untested and type-only files were being included in threshold calculations. This PR keeps the strict quality bar while making the metric align with practical, executable code coverage.

## Changes
- `tests/connectors.test.ts`
  - Adds null/undefined trend tests for Dexcom and Libre
  - Adds non-integer in-range Libre trend fallback test
  - Adds Nightscout invalid `dateString` fallback and both timestamp error-path tests
- `tests/tir-enhanced.test.ts`
  - Adds default-interval fallback tests for invalid timestamps and non-positive deltas
- `vitest.config.ts`
  - Excludes `src/connectors/types.ts` and `src/interop/types.ts` from coverage
- `README.md`
  - Updates test-count mentions to `295` to match current reality

## Test plan
- [x] Run `pnpm test:coverage`
- [x] Confirm global coverage thresholds pass at 100% (statements, branches, functions, lines)
- [x] Confirm connector and enhanced TIR edge behavior is covered by explicit tests

## Notes
No runtime production logic was changed in this PR; scope is test coverage correctness and documentation accuracy.

Made with [Cursor](https://cursor.com)